### PR TITLE
Add new feature to count messages by date

### DIFF
--- a/lib/chat_api/reporting.ex
+++ b/lib/chat_api/reporting.ex
@@ -31,6 +31,20 @@ defmodule ChatApi.Reporting do
     |> Repo.all()
   end
 
+  def count_sent_messages() do
+    Message
+    |> where([message], not is_nil(message.user_id))
+    |> count_grouped_by_date()
+    |> Repo.all()
+  end
+
+  def count_received_messages() do
+    Message
+    |> where([message], not is_nil(message.customer_id))
+    |> count_grouped_by_date()
+    |> Repo.all()
+  end
+
   def count_grouped_by_date(query, field \\ :inserted_at) do
     query
     |> group_by([r], fragment("date(?)", field(r, ^field)))

--- a/test/chat_api/reporting_test.exs
+++ b/test/chat_api/reporting_test.exs
@@ -115,5 +115,84 @@ defmodule ChatApi.ReportingTest do
                %{date: ~D[2020-09-03], count: 1}
              ] = Reporting.conversations_by_date(account.id)
     end
+
+    test "count_sent_messages/0 groups by date correctly", %{
+      account: account,
+      customer: customer
+    } do
+      user_2 = user_fixture(account)
+      user_3 = user_fixture(account)
+      conversation = conversation_fixture(account, customer)
+
+      message_fixture(account, conversation, %{
+        inserted_at: ~N[2020-09-01 12:00:00],
+        user_id: user_2.id
+      })
+
+      message_fixture(account, conversation, %{
+        inserted_at: ~N[2020-09-02 12:00:00],
+        user_id: user_2.id
+      })
+
+      message_fixture(account, conversation, %{
+        inserted_at: ~N[2020-09-03 12:00:00],
+        user_id: user_3.id
+      })
+
+      message_fixture(account, conversation, %{
+        inserted_at: ~N[2020-09-03 12:00:00],
+        user_id: user_3.id
+      })
+
+      message_fixture(account, conversation, %{
+        inserted_at: ~N[2020-09-03 12:00:00],
+        customer_id: customer.id
+      })
+
+      assert [
+               %{date: ~D[2020-09-01], count: 1},
+               %{date: ~D[2020-09-02], count: 1},
+               %{date: ~D[2020-09-03], count: 2}
+             ] = Reporting.count_sent_messages()
+    end
+
+    test "count_received_messages/0 groups by date correctly", %{
+      account: account,
+      customer: customer
+    } do
+      user_2 = user_fixture(account)
+      conversation = conversation_fixture(account, customer)
+
+      message_fixture(account, conversation, %{
+        inserted_at: ~N[2020-09-01 12:00:00],
+        customer_id: customer.id
+      })
+
+      message_fixture(account, conversation, %{
+        inserted_at: ~N[2020-09-02 12:00:00],
+        customer_id: customer.id
+      })
+
+      message_fixture(account, conversation, %{
+        inserted_at: ~N[2020-09-03 12:00:00],
+        customer_id: customer.id
+      })
+
+      message_fixture(account, conversation, %{
+        inserted_at: ~N[2020-09-03 12:00:00],
+        user_id: user_2.id
+      })
+
+      message_fixture(account, conversation, %{
+        inserted_at: ~N[2020-09-03 12:00:00],
+        user_id: user_2.id
+      })
+
+      assert [
+               %{date: ~D[2020-09-01], count: 1},
+               %{date: ~D[2020-09-02], count: 1},
+               %{date: ~D[2020-09-03], count: 1}
+             ] = Reporting.count_received_messages()
+    end
   end
 end


### PR DESCRIPTION
### Description

Added 2 new functions on `reporting.ex`:
1. count_sent_messages/0 (fetch messages that contains user_id, grouped by date)
2. count_received_messages/0 (fetch messages that contains customer_id, grouped by date)

### Issue

#255 

### Screenshots

N/A updates on frontend

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
